### PR TITLE
seconds including fraction used scientific notation if less then 1e-4

### DIFF
--- a/date.lua
+++ b/date.lua
@@ -598,8 +598,8 @@
     -- Misc --
     -- Year, if year is in BCE, prints the BCE Year representation, otherwise result is similar to "%Y" (1 BCE, 40 BCE)
     ['%\b']=function(self) local x = self:getyear() return fmt("%.4d%s", x>0 and x or (-x+1), x>0 and "" or " BCE") end,
-    -- Seconds including fraction (59.998, 01.123)
-    ['%\f']=function(self) local x = self:getfracsec() return fmt("%s%.9g",x >= 10 and "" or "0", x) end,
+    -- Seconds including fraction (59.998, 01.123) 
+    ['%\f']=function(self) local x = self:getfracsec() return fmt("%s%.9f",x >= 10 and "" or "0", x) end,
     -- percent character %
     ['%%']=function(self) return "%" end,
     -- Group Spec --

--- a/spec/date_spec.lua
+++ b/spec/date_spec.lua
@@ -180,6 +180,9 @@ describe("Testing the 'date' module", function()
     assert(d:fmt('%T') == d:fmt("%H:%M:%S"))        -- 24-hour time, from 00:00:00 (06:55:15)
     assert(d:fmt('%a %A %b %B') == "Tue Tuesday Oct October")
     assert(d:fmt('%C %d') == "15 05", d:fmt('%C %d'))
+    local d2 = date(1446747300.00008)
+    assert.is.equals(d2:fmt('%\f'),"00.000080109")
+
   end)
 
   it("Tests 'getclockhour()'", function()


### PR DESCRIPTION
socket.getdate() returns date in microseconds. If the minute is 0 and its a significantly small amount of microseconds the string format for fractional seconds outputting scientific notation. This changes the format string from %g to %f for fractional seconds