### PR TITLE
Year 2000 for 00-40

### DIFF
--- a/date.lua
+++ b/date.lua
@@ -339,7 +339,7 @@
         elseif sw("^(%d+)[/\\%s,-]?%s*") then --print("$Digits")
           x, c = tonumber(sw[1]), len(sw[1])
           if (x >= 70) or (m and d and (not y)) or (c > 3) then
-            sety( x + ((x >= 100 or c>3)and 0 or 1900) )
+            sety( x + ((x >= 100 or c>3) and 0 or x<41 and 2000 or 1900) )
           else
             if m then setd(x) else m = x end
           end

--- a/samples/tests.lua
+++ b/samples/tests.lua
@@ -33,12 +33,12 @@ assert(date("Jul 27 2006 PDT") == date(2006,07,27,7,0,0))
 
 
 --Date Format.  Short dates can use either a "/" or "-" date separator, but must follow the month/day/year format 
-assert(date("02-03-04")==date(1904,02,03))
+assert(date("02-03-04")==date(2004,02,03))
 assert(date("12/25/98")==date(1998,12,25))
 
 
 --Long dates of the form "July 10 1995" can be given with the year, month, and day in any order, and the year in 2-digit or 4-digit form. If you use the 2-digit form, the year must be greater than or equal to 70. 
-assert(date("Feb-03-04")==date(1904,02,03))
+assert(date("Feb-03-04")==date(2004,02,03))
 assert(date("December 25 1998")==date(1998,12,25))
 
 

--- a/spec/date_spec.lua
+++ b/spec/date_spec.lua
@@ -22,12 +22,12 @@ describe("Testing the 'date' module", function()
     assert(date("Jul 27 2006 PDT") == date(2006,07,27,7,0,0))
     -- Date Format.  Short dates can use either a "/" or "-" date separator, 
     -- but must follow the month/day/year format
-    assert(date("02-03-04")==date(1904,02,03))
+    assert(date("02-03-04")==date(2004,02,03))
     assert(date("12/25/98")==date(1998,12,25))
     -- Long dates of the form "July 10 1995" can be given with the year, month, 
     -- and day in any order, and the year in 2-digit or 4-digit form. If you use 
     -- the 2-digit form, the year must be greater than or equal to 70.
-    assert(date("Feb-03-04")==date(1904,02,03))
+    assert(date("Feb-03-04")==date(2004,02,03))
     assert(date("December 25 1998")==date(1998,12,25))
     -- Follow the year with BC or BCE to indicate that the year is before common era.
     assert(date("Feb 3 0003 BC")==date(-2,02,03))


### PR DESCRIPTION
Date parse: if 2-digit year is greater than or equal to 41, the century used is 1900, otherwise 2000
