### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/date-2.2-2.rockspec
+++ b/date-2.2-2.rockspec
@@ -1,6 +1,6 @@
 local package_name = "date"
 local package_version = "2.2"
-local rockspec_revision = "1"
+local rockspec_revision = "2"
 local github_account_name = "Tieske"
 local github_repo_name = package_name
 local git_checkout = package_version == "dev" and "master" or ("version_"..package_version)
@@ -9,7 +9,7 @@ package = package_name
 version = package_version .. "-" .. rockspec_revision
 
 source = {
-  url = "git://github.com/"..github_account_name.."/"..github_repo_name..".git",
+  url = "git+https://github.com/"..github_account_name.."/"..github_repo_name..".git",
   branch = git_checkout
 }
 


### PR DESCRIPTION
GitHub is going to disable unencrypted Git protocol, so `git://` URLs
will stop working soon (see [1]).

Bumped the rockspec revision.

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/