### PR TITLE
fix(parse): offset parsing when seconds are decimal

### DIFF
--- a/spec/date_spec.lua
+++ b/spec/date_spec.lua
@@ -72,6 +72,10 @@ describe("Testing the 'date' module", function()
     assert(date("1976-W01-1 13:00+01:00")==date(1975,12,29,12))
     assert(date("1976-W01-1 0700-0500  ")==date(1975,12,29,12))
 
+    assert(date("2023-08-22T17:40:23.308574-05:00")==date(2023,08,22,22,40,23.308574000))
+    assert(date("2023-08-22T19:40:23.308574+08:45")==date(2023,08,22,10,55,23.308574000))
+    assert(date("2023-08-22T19:40:23-09:30")==date(2023,08,23,5,10,23))
+
     local a = date(2006, 8, 13)   assert(a == date("Sun Aug 13 2006"))
     local b = date("Jun 13 1999") assert(b == date(1999, 6, 13))
     local c = date(1234483200)    assert(c == date("Feb 13 2009"))

--- a/spec/date_spec.lua
+++ b/spec/date_spec.lua
@@ -72,8 +72,15 @@ describe("Testing the 'date' module", function()
     assert(date("1976-W01-1 13:00+01:00")==date(1975,12,29,12))
     assert(date("1976-W01-1 0700-0500  ")==date(1975,12,29,12))
 
+    -- timezone offset with colon
     assert(date("2023-08-22T17:40:23.308574-05:00")==date(2023,08,22,22,40,23.308574000))
+    -- timezone offset without colon
+    assert(date("2023-08-22T17:40:23.308574-0500")==date(2023,08,22,22,40,23.308574000))
+    -- timezone offset without minutes
+    assert(date("2023-08-22T17:40:23.308574-05")==date(2023,08,22,22,40,23.308574000))
+    -- timezone offset without colon with positive offset and non-zero minutes
     assert(date("2023-08-22T19:40:23.308574+08:45")==date(2023,08,22,10,55,23.308574000))
+    -- timezone offset without colon with no decimal seconds
     assert(date("2023-08-22T19:40:23-09:30")==date(2023,08,23,5,10,23))
 
     local a = date(2006, 8, 13)   assert(a == date("Sun Aug 13 2006"))

--- a/src/date.lua
+++ b/src/date.lua
@@ -321,7 +321,7 @@
     local function setzc(zs,zh,zm) setz( ((tonumber(zh)*60) + tonumber(zm))*( zs=='+' and -1 or 1) ) end
 
     if not (sw("^(%d%d%d%d)",sety) and (sw("^(%-?)(%d%d)%1(%d%d)",function(_,a,b) setm(tonumber(a)); setd(tonumber(b)) end) or sw("^(%-?)[Ww](%d%d)%1(%d?)",function(_,a,b) w, u = tonumber(a), tonumber(b or 1) end) or sw("^%-?(%d%d%d)",setj) or sw("^%-?(%d%d)",function(a) setm(a);setd(1) end))
-    and ((sw("^%s*[Tt]?(%d%d):?",seth) and sw("^(%d%d):?",setr) and sw("^(%d%d)",sets) and sw("^([,%.]%d+)",adds))
+    and ((sw("^%s*[Tt]?(%d%d):?",seth) and sw("^(%d%d):?",setr) and sw("^(%d%d)",sets) and sw("^([,%.]%d+)",adds) and sw("%s*([+-])(%d%d):?(%d%d)%s*$",setzc))
       or sw:finish() or (sw"^%s*$" or sw"^%s*[Zz]%s*$" or sw("^%s-([%+%-])(%d%d):?(%d%d)%s*$",setzc) or sw("^%s*([%+%-])(%d%d)%s*$",setzn))
       )  )
     then --print(y,m,d,h,r,s,z,w,u,j)


### PR DESCRIPTION
# Context

This addresses https://github.com/Tieske/date/issues/32
as well as adds test cases for when seconds of a timestamp are represented as a decimal, the offset +/-HH:MM is not respected for the timezone offset

# Test Plan

Added 3 more tests and verified no other tests break